### PR TITLE
Fix: Mentions the author of replied message instead of person inputting the command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,6 @@ The prompt used is around ~186 tokens. Assuming an average message size of 50 to
 The machine picked is an EC2-Mini, and forms the majority of the hosting cost. You could likely drop this significantly by using spot pricing, but it currently works out to around $0.26 per day.
 
 ## Feature Creep
-The bot also provides one-sentence answers to user queries upon request, but this feature was just for fun. 
+The bot also provides one-sentence answers to user queries upon request, but this feature was just for fun.
+
+Added a command (`!ask`) to help discourage meta-questions by linking to [Don't ask to ask, just ask](https://dontasktoask.com/), promoting more effective community interactions.

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ async fn handle_roadmap(ctx: &Context, message: &Message) -> anyhow::Result<()> 
 async fn handle_ask(ctx: &Context, message: &Message) -> anyhow::Result<()> {
     let response = "Don't ask to ask, just ask! \nhttps://dontasktoask.com/".to_string();
 
-    if let Some(message_reply) = message.referenced_message.clone() {
+    if let Some(ref message_reply) = message.referenced_message {
         reply_chunked(
             ctx,
             message_reply.author.mention(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,9 +144,16 @@ async fn handle_ask(ctx: &Context, message: &Message) -> anyhow::Result<()> {
     let response = "Don't ask to ask, just ask! \nhttps://dontasktoask.com/".to_string();
 
     if let Some(message_reply) = message.referenced_message.clone() {
-        reply_chunked(ctx, message_reply.author.mention(), message_reply.channel_id, response).await?;
+        reply_chunked(
+            ctx,
+            message_reply.author.mention(),
+            message_reply.channel_id,
+            response,
+        )
+        .await?;
     } else {
-        message.channel_id
+        message
+            .channel_id
             .send_message(&ctx.http, CreateMessage::new().content(response))
             .await?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,14 +141,18 @@ async fn handle_roadmap(ctx: &Context, message: &Message) -> anyhow::Result<()> 
 }
 
 async fn handle_ask(ctx: &Context, message: &Message) -> anyhow::Result<()> {
-    reply_chunked(
-        ctx,
-        message.author.mention(),
-        message.channel_id,
-        "Don't ask to ask, just ask! \nhttps://dontasktoask.com/".to_string(),
-    )
-    .await
+    let response = "Don't ask to ask, just ask! \nhttps://dontasktoask.com/".to_string();
+
+    if let Some(message_reply) = message.referenced_message.clone() {
+        reply_chunked(ctx, message_reply.author.mention(), message_reply.channel_id, response).await?;
+    } else {
+        message.channel_id
+            .send_message(&ctx.http, CreateMessage::new().content(response))
+            .await?;
+    }
+    Ok(())
 }
+
 async fn handle_message(ctx: Context, message: Message) {
     match is_message_suspicious(
         &message,


### PR DESCRIPTION
Added a conditional to check if the command is a reply. If so, it mentions the author of the reply instead of the person using "!ask". If not, it just sends the response message as is, without using reply_chunked (no mention).